### PR TITLE
Add sample PMR

### DIFF
--- a/tests/samples/pmr-sample.yaml
+++ b/tests/samples/pmr-sample.yaml
@@ -1,0 +1,28 @@
+profiles:
+- name: ml-engineers
+  owner:
+    kind: user
+    name: admin@canonical.com
+  resources:
+    hard:
+      limits.cpu: "1"
+  contributors:
+  - name: kimonas@canonical.com
+    role: admin
+  - name: michal@canonical.com
+    role: edit
+  - name: andreea@canonical.com
+    role: view
+- name: data-engineers
+  owner:
+    kind: user
+    name: admin@canonical.com
+  contributors:
+  - name: daniela@canonical.com
+    role: edit
+  - name: noha@canonical.com
+    role: edit
+  - name: manos@canonical.com
+    role: view
+  - name: orfeas@canonical.com
+    role: view


### PR DESCRIPTION
Closes #22 

This PR adds a sample PMR under `tests/samples/`, which will be used by the charm integration tests to validate that the Profiles are updated based on the PMR information.


You can test that the code is `yaml` file is valid with the following code:
```python
from pathlib import Path
import yaml

from src.profiles_management.pmr.classes import Profile
from src.profiles_management.pmr.classes import ProfilesManagementRepresentation

yaml_file = yaml.safe_load(Path("tests/samples/pmr-sample.yaml").read_text())

pmr = ProfilesManagementRepresentation()
for profile_dict in yaml_file["profiles"]:
    pmr.add_profile(Profile.model_validate(profile_dict))
    print(pmr.profiles)
```