### PR TITLE
PMR: Extend `create_or_update_profiles()` to create Profiles and update ResourceQuota

### DIFF
--- a/src/profiles_management/create_or_update.py
+++ b/src/profiles_management/create_or_update.py
@@ -92,5 +92,5 @@ def create_or_update_profiles(client: Client, pmr: ProfilesManagementRepresentat
             log.info("No Profile CR exists for Profile %s, creating it.", profile_name)
             existing_profile = profiles.apply_pmr_profile(client, profile)
 
-        log.info("Creating or updating the ResourceQuota for the Profile.")
+        log.info("Creating or updating the ResourceQuota for Profile %s", profile_name)
         profiles.update_resource_quota(client, existing_profile, profile)

--- a/src/profiles_management/create_or_update.py
+++ b/src/profiles_management/create_or_update.py
@@ -76,6 +76,7 @@ def create_or_update_profiles(client: Client, pmr: ProfilesManagementRepresentat
     for profile in profiles.list_profiles(client):
         existing_profiles[get_name(profile)] = profile
 
+    # Remove access to all stale Profiles
     log.info("Removing access to all stale Profiles.")
     for profile_name, existing_profile in existing_profiles.items():
         if not pmr.has_profile(profile_name):

--- a/src/profiles_management/helpers/k8s.py
+++ b/src/profiles_management/helpers/k8s.py
@@ -70,7 +70,7 @@ def ensure_namespace_is_deleted(namespace: str, client: Client):
 
 @tenacity.retry(stop=tenacity.stop_after_delay(60), wait=tenacity.wait_fixed(2), reraise=True)
 def ensure_namespace_exists(ns: str, client: Client):
-    """Check if the name exists with retries.
+    """Check if the namespace exists with retries.
 
     The retries will catch the 404 errors if the namespace doesn't exist.
 

--- a/src/profiles_management/helpers/kfam.py
+++ b/src/profiles_management/helpers/kfam.py
@@ -18,7 +18,14 @@ AuthorizationPolicy = create_namespaced_resource(
 
 
 def has_kfam_annotations(resource: GenericNamespacedResource | RoleBinding) -> bool:
-    """Check if resource has "user" and "role" KFAM annotations."""
+    """Check if resource has "user" and "role" KFAM annotations.
+
+    Args:
+        resource: The RoleBinding or AuthorizationPolicy to check if it has KFAM annotations.
+
+    Returns:
+        A boolean if the provided resources has a `role` and `user` annotation.
+    """
     if resource.metadata and resource.metadata.annotations:
         return "role" in resource.metadata.annotations and "user" in resource.metadata.annotations
 
@@ -26,7 +33,14 @@ def has_kfam_annotations(resource: GenericNamespacedResource | RoleBinding) -> b
 
 
 def resource_is_for_profile_owner(resource: GenericNamespacedResource | RoleBinding) -> bool:
-    """Check if the resource is for the Profile owner."""
+    """Check if the resource is for the Profile owner.
+
+    Args:
+        resource: The RoleBinding or AuthorizationPolicy to check if it belongs to a Profile owner.
+
+    Returns:
+        A boolean representing if the provided resource belongs to the Profile owner.
+    """
     if resource.metadata:
         return (
             resource.metadata.name == "ns-owner-access-istio"

--- a/src/profiles_management/helpers/profiles.py
+++ b/src/profiles_management/helpers/profiles.py
@@ -4,9 +4,16 @@ import logging
 from typing import Iterator
 
 from lightkube import Client
-from lightkube.generic_resource import GenericGlobalResource, create_global_resource
+from lightkube.generic_resource import (
+    GenericGlobalResource,
+    GenericNamespacedResource,
+    create_global_resource,
+)
+from lightkube.types import PatchType
 
 from profiles_management.helpers import k8s
+from profiles_management.helpers.k8s import ensure_namespace_exists
+from profiles_management.pmr import classes
 
 Profile = create_global_resource(
     group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
@@ -47,3 +54,95 @@ def remove_profile(profile: GenericGlobalResource, client: Client, wait_namespac
     if wait_namespace:
         log.info("Waiting for created namespace to be deleted.")
         k8s.ensure_namespace_is_deleted(nm, client)
+
+
+def lightkube_profile_from_pmr_profile(profile: classes.Profile) -> GenericGlobalResource:
+    """Create lightkube GenericGlobalResource from PMR Profile class instance.
+
+    Args:
+        profile: The PMR Profile to convert to a lightkube Profile.
+
+    Returns:
+        A lightkube Profile object.
+    """
+    quota_spec = (
+        {}
+        if profile.resources is None
+        else profile.resources.model_dump(by_alias=True, exclude_none=True)
+    )
+
+    return Profile.from_dict(
+        {
+            "metadata": {
+                "name": profile.name,
+            },
+            "spec": {
+                "owner": {
+                    "kind": profile.owner.kind,
+                    "name": profile.owner.name,
+                },
+                "resourceQuotaSpec": quota_spec,
+            },
+        }
+    )
+
+
+def apply_pmr_profile(
+    client: Client, profile: classes.Profile, wait_namespace=True
+) -> GenericGlobalResource:
+    """Apply a PMR Profile and return the created API Object from client.apply().
+
+    Args:
+        client: The lightkube client to use.
+        profile: The PMR Profile to create in the cluster.
+        wait_namespace: Whether to wait for the namespace of the Profile to be
+                        created before returning.
+
+    Returns:
+        The created Profile lightkube object.
+    """
+    profile_obj = lightkube_profile_from_pmr_profile(profile)
+    applied_profile = client.apply(profile_obj)
+
+    if isinstance(applied_profile, GenericNamespacedResource):
+        raise ValueError("Applied Profile is a namespaced resource.")
+
+    if wait_namespace:
+        log.info("Waiting for Profile namespace to be created...")
+        ensure_namespace_exists(profile.name, client)
+
+    return applied_profile
+
+
+def update_resource_quota(
+    client: Client, existing_profile: GenericGlobalResource, pmr_profile: classes.Profile
+):
+    """Update the ResourceQuota in the existing Profile, based on Profile defined in PMR.
+
+    If the ResourceQuota in the existing Profile and the PMR Profile are the same, then no
+    update will happen.
+
+    Args:
+        client: The lightkube client to use.
+        existing_profile: The existing Profile lightkube object in the cluster.
+        pmr_profile: To update the ResourceQuota in the cluster from this object.
+    """
+    existing_resource_quota = classes.ResourceQuotaSpecModel.model_validate(
+        existing_profile["spec"]["resourceQuotaSpec"]
+    )
+
+    # pydantic handles comparison of the fields, plus comparison with None
+    if existing_resource_quota == pmr_profile.resources:
+        log.info("ResourceQuota in applied Profile and in PMR are the same. Nothing to do.")
+        return
+
+    log.info("Different ResourceQuotaSpec in Profile and in PMR.")
+    log.info("PMR Profile Quota: %s", pmr_profile.resources)
+    log.info("Existing Profile Quota: %s", existing_resource_quota)
+
+    log.info("Updating the ResourceQuotaSpec in the Profile CR.")
+    quota_spec = pmr_profile.resources.model_dump() if pmr_profile.resources is not None else {}
+    patch = {"spec": {"resourceQuotaSpec": quota_spec}}
+
+    client.patch(Profile, name=pmr_profile.name, obj=patch, patch_type=PatchType.MERGE)
+    log.info("Successfully patched resourceQuotaSpec of Profile: %s", pmr_profile.name)

--- a/src/profiles_management/helpers/profiles.py
+++ b/src/profiles_management/helpers/profiles.py
@@ -15,7 +15,7 @@ from profiles_management.helpers import k8s
 from profiles_management.helpers.k8s import ensure_namespace_exists
 from profiles_management.pmr import classes
 
-Profile = create_global_resource(
+ProfileLightkube = create_global_resource(
     group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
 )
 
@@ -31,7 +31,7 @@ def list_profiles(client: Client) -> Iterator[GenericGlobalResource]:
     Returns:
         Iterator of Profiles in the cluster.
     """
-    return client.list(Profile)
+    return client.list(ProfileLightkube)
 
 
 def remove_profile(profile: GenericGlobalResource, client: Client, wait_namespace=True):
@@ -49,7 +49,7 @@ def remove_profile(profile: GenericGlobalResource, client: Client, wait_namespac
     """
     nm = k8s.get_name(profile)
     log.info("Removing Profile: %s", nm)
-    client.delete(Profile, nm)
+    client.delete(ProfileLightkube, nm)
 
     if wait_namespace:
         log.info("Waiting for created namespace to be deleted.")
@@ -71,7 +71,7 @@ def lightkube_profile_from_pmr_profile(profile: classes.Profile) -> GenericGloba
         else profile.resources.model_dump(by_alias=True, exclude_none=True)
     )
 
-    return Profile.from_dict(
+    return ProfileLightkube.from_dict(
         {
             "metadata": {
                 "name": profile.name,
@@ -144,5 +144,5 @@ def update_resource_quota(
     quota_spec = pmr_profile.resources.model_dump() if pmr_profile.resources is not None else {}
     patch = {"spec": {"resourceQuotaSpec": quota_spec}}
 
-    client.patch(Profile, name=pmr_profile.name, obj=patch, patch_type=PatchType.MERGE)
+    client.patch(ProfileLightkube, name=pmr_profile.name, obj=patch, patch_type=PatchType.MERGE)
     log.info("Successfully patched resourceQuotaSpec of Profile: %s", pmr_profile.name)

--- a/src/profiles_management/pmr/classes.py
+++ b/src/profiles_management/pmr/classes.py
@@ -16,7 +16,8 @@ import logging
 from enum import StrEnum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+from pydantic.alias_generators import to_camel
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class Operator(StrEnum):
     DoesNotExist = "DoesNotExist"
 
 
-class ScopedResourceSelectorRequirement(BaseModel, extra="forbid"):
+class ScopedResourceSelectorRequirement(BaseModel):
     """Class for objects of matchExpressions of ResourceQuotaSpec.
 
     Args:
@@ -44,12 +45,14 @@ class ScopedResourceSelectorRequirement(BaseModel, extra="forbid"):
         ValidationError: From pydantic if the validation failed.
     """
 
+    model_config = ConfigDict(alias_generator=to_camel, extra="forbid")
+
     operator: Operator
     scope_name: str
     values: Optional[List[str]] = None
 
 
-class ScopeSelector(BaseModel, extra="forbid"):
+class ScopeSelector(BaseModel):
     """Class for ScopeSelector of ResourceQuotaSpec.
 
     Args:
@@ -59,10 +62,12 @@ class ScopeSelector(BaseModel, extra="forbid"):
         ValidationError: From pydantic if the validation failed.
     """
 
+    model_config = ConfigDict(alias_generator=to_camel, extra="forbid")
+
     match_expressions: List[ScopedResourceSelectorRequirement]
 
 
-class ResourceQuotaSpecModel(BaseModel, extra="forbid"):
+class ResourceQuotaSpecModel(BaseModel):
     """Class for K8s ResourceQuotaSpec.
 
     Args:
@@ -74,6 +79,8 @@ class ResourceQuotaSpecModel(BaseModel, extra="forbid"):
     Raises:
         ValidationError: From pydantic if the validation failed.
     """
+
+    model_config = ConfigDict(alias_generator=to_camel, extra="forbid")
 
     hard: Optional[Dict[str, Any]] = None
     scope_selector: Optional[ScopeSelector] = None

--- a/tests/integration/profiles_management/helpers/k8s.py
+++ b/tests/integration/profiles_management/helpers/k8s.py
@@ -43,27 +43,6 @@ def get_name(res: GenericNamespacedResource | GenericGlobalResource) -> str:
     return res.metadata.name
 
 
-def get_namespace(res: GenericNamespacedResource) -> str:
-    """Return the name from a generic lightkube resource.
-
-    Args:
-        res: The namespaced resource to get the namespace of
-
-    Raises:
-        ValueError: if the object doesn't have metadata or metadata.namespace
-
-    Returns:
-        The namespace of the resource from its metadata.
-    """
-    if not res.metadata:
-        pytest.xfail("Couldn't detect namespace, object has no metadata: %s" % res)
-
-    if not res.metadata.namespace:
-        pytest.xfail("Couldn't detect namespace from metadata: %s" % res)
-
-    return res.metadata.namespace
-
-
 def load_namespaced_objects_from_file(
     file_path: str, context: dict = {}
 ) -> List[codecs.AnyResource]:

--- a/tests/integration/profiles_management/helpers/kfam.py
+++ b/tests/integration/profiles_management/helpers/kfam.py
@@ -19,7 +19,14 @@ codecs.resource_registry.register(AuthorizationPolicy)
 
 
 def has_kfam_annotations(resource: GenericNamespacedResource | RoleBinding) -> bool:
-    """Check if resource has "user" and "role" KFAM annotations."""
+    """Check if resource has "user" and "role" KFAM annotations.
+
+    Args:
+        resource: The RoleBinding or AuthorizationPolicy to check if it has KFAM annotations.
+
+    Returns:
+        A boolean if the provided resources has a `role` and `user` annotation.
+    """
     if resource.metadata and resource.metadata.annotations:
         return "role" in resource.metadata.annotations and "user" in resource.metadata.annotations
 
@@ -27,7 +34,14 @@ def has_kfam_annotations(resource: GenericNamespacedResource | RoleBinding) -> b
 
 
 def resource_is_for_profile_owner(resource: GenericNamespacedResource | RoleBinding) -> bool:
-    """Check if the resource is for the Profile owner."""
+    """Check if the resource is for the Profile owner.
+
+    Args:
+        resource: The RoleBinding or AuthorizationPolicy to check if it belongs to a Profile owner.
+
+    Returns:
+        A boolean representing if the provided resource belongs to the Profile owner.
+    """
     if resource.metadata:
         return (
             resource.metadata.name == "ns-owner-access-istio"

--- a/tests/integration/profiles_management/helpers/profiles.py
+++ b/tests/integration/profiles_management/helpers/profiles.py
@@ -14,7 +14,7 @@ from tests.integration.profiles_management.helpers import k8s
 
 log = logging.getLogger(__name__)
 
-Profile = create_global_resource(
+ProfileLightkube = create_global_resource(
     group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
 )
 
@@ -32,7 +32,7 @@ def get_profile(client: Client, name: str) -> GenericGlobalResource:
     Returns:
         The Profile lightkube object from the cluster.
     """
-    return client.get(Profile, name=name)
+    return client.get(ProfileLightkube, name=name)
 
 
 def load_profile_from_file(file_path: str, context: dict = {}) -> codecs.AnyResource:
@@ -100,7 +100,7 @@ def remove_profile(profile: GenericGlobalResource, client: Client, wait_namespac
     """
     nm = k8s.get_name(profile)
     log.info("Removing Profile: %s", nm)
-    client.delete(Profile, nm)
+    client.delete(ProfileLightkube, nm)
 
     if wait_namespace:
         log.info("Waiting for created namespace to be deleted.")

--- a/tests/integration/profiles_management/helpers/profiles.py
+++ b/tests/integration/profiles_management/helpers/profiles.py
@@ -19,6 +19,22 @@ Profile = create_global_resource(
 )
 
 
+def get_profile(client: Client, name: str) -> GenericGlobalResource:
+    """Get a Profile from the cluster.
+
+    Args:
+        client: The lightkube client to use.
+        name: The name of the Profile to get.
+
+    Raises:
+        ApiError: If there are errors fetching the Profile (i.e. doesn't exist)
+
+    Returns:
+        The Profile lightkube object from the cluster.
+    """
+    return client.get(Profile, name=name)
+
+
 def load_profile_from_file(file_path: str, context: dict = {}) -> codecs.AnyResource:
     """Load only Profiles from a YAML file.
 

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -88,7 +88,7 @@ async def test_new_profiles_created(lightkube_client: Client):
 @pytest.mark.asyncio
 async def test_update_resource_quota(lightkube_client: Client):
     profile_path = TESTS_YAMLS_PATH + "/profile.yaml"
-    log.info("Loading test YAMLs from: %s",  profile_path)
+    log.info("Loading test YAMLs from: %s", profile_path)
 
     ns = "test"
     context = {"namespace": ns}

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -88,7 +88,7 @@ async def test_new_profiles_created(lightkube_client: Client):
 @pytest.mark.asyncio
 async def test_update_resource_quota(lightkube_client: Client):
     profile_path = TESTS_YAMLS_PATH + "/profile.yaml"
-    log.info("Loading test yamls from: %s" % profile_path)
+    log.info("Loading test YAMLs from: %s",  profile_path)
 
     ns = "test"
     context = {"namespace": ns}

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -5,6 +5,13 @@ from lightkube import Client
 
 from profiles_management.create_or_update import create_or_update_profiles
 from profiles_management.pmr import classes
+from profiles_management.pmr.classes import (
+    Owner,
+    Profile,
+    ProfilesManagementRepresentation,
+    ResourceQuotaSpecModel,
+    UserKind,
+)
 from tests.integration.profiles_management.helpers import k8s, kfam, profiles
 
 log = logging.getLogger(__name__)
@@ -49,3 +56,68 @@ async def test_remove_access_to_stale_profiles(
 
     log.info("Removing test Profile and resources in it.")
     profiles.remove_profile(profile, lightkube_client)
+
+
+@pytest.mark.asyncio
+async def test_new_profiles_created(lightkube_client: Client):
+    pmr = classes.ProfilesManagementRepresentation()
+
+    users = ["noha", "orfeas"]
+    expected_quota = classes.ResourceQuotaSpecModel.model_validate({"hard": {"cpu": "1"}})
+    for user in users:
+        pmr.add_profile(
+            classes.Profile(
+                name=user,
+                owner=classes.Owner(name=user, kind=classes.UserKind.USER),
+                resources=expected_quota,
+            )
+        )
+
+    create_or_update_profiles(lightkube_client, pmr)
+
+    log.info("Will check if Profiles were created as expected")
+    for user in users:
+        created_profile = profiles.get_profile(lightkube_client, user)
+        created_profile_quota = classes.ResourceQuotaSpecModel.model_validate(
+            created_profile["spec"]["resourceQuotaSpec"]
+        )
+        assert created_profile_quota == expected_quota
+        profiles.remove_profile(created_profile, lightkube_client)
+
+
+@pytest.mark.asyncio
+async def test_update_resource_quota(lightkube_client: Client):
+    profile_path = TESTS_YAMLS_PATH + "/profile.yaml"
+    log.info("Loading test yamls from: %s" % profile_path)
+
+    ns = "test"
+    context = {"namespace": ns}
+    profile_contents = profiles.load_profile_from_file(profile_path, context)
+
+    log.info("Creating Profile and waiting for Namespace to be created...")
+    profile = profiles.apply_profile(profile_contents, lightkube_client, wait_namespace=True)
+    log.info("Created Profile has quota: %s", profile["spec"]["resourceQuotaSpec"])
+
+    expected_quota = ResourceQuotaSpecModel.model_validate({"hard": {"cpu": "1"}})
+    pmr_profile = Profile(
+        name=ns,
+        owner=Owner(name="test", kind=UserKind.USER),
+        contributors=[],
+        resources=expected_quota,
+    )
+
+    log.info("Updating Profile CR from expected PMR Profile: %s", pmr_profile)
+    create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
+
+    updated_profile = profiles.get_profile(lightkube_client, ns)
+    updated_quota = ResourceQuotaSpecModel.model_validate(
+        updated_profile["spec"]["resourceQuotaSpec"]
+    )
+
+    log.info("Will compare the following resourceQuotaSpec pydantic model objects.")
+    log.info("Expected quota: %s", expected_quota)
+    log.info("Profile's quota: %s", updated_quota)
+    assert updated_quota == expected_quota
+
+    log.info("Removing test Profile and resources in it")
+    profiles.remove_profile(profile, lightkube_client, wait_namespace=True)

--- a/tests/integration/profiles_management/yamls/profile.yaml
+++ b/tests/integration/profiles_management/yamls/profile.yaml
@@ -8,3 +8,4 @@ spec:
   owner:
     kind: User
     name: user@example.com
+  resourceQuotaSpec: {}


### PR DESCRIPTION
Closes https://github.com/canonical/github-profiles-automator/issues/10

This PR will add the following functionalities to the main `create_or_update_profiles()` function:
1. New Profiles will be created, if defined in the PMR but don't exist in the cluster
2. Existing Profiles' `resourceQuotaSpec` will be updated, if they are different from PMR's

## Changes
- Update the PMR classes to use [alias](https://docs.pydantic.dev/latest/concepts/alias/#using-an-aliasgenerator), for converting to/from `camelCase`
- Helpers for creating a Profile CR, from a PMR Profile, using the above for converting ResourceQuotaSpec to `camelCase`
- Helpers for updating a Profile's `resourceQuotaSpec`, with `client.apply`
- Removed `get_namespace` from test helpers, which wasn't used anywhere

## Review Notes
For updating a Profile, to update the `ResourceQuotaSpec`, the code is **not** using [chisme's apply_many](https://github.com/canonical/charmed-kubeflow-chisme/blob/3f13ba3f6f4daaf584d0b757eeb3014f0ae91714/src/charmed_kubeflow_chisme/lightkube/batch/_many.py#L22C5-L22C15), but instead `client.patch`. More can be found in https://github.com/canonical/github-profiles-automator/issues/10

I've included in this PR both the code for creating a Profile and also updating the `ResourceQuotaSpec`, because of the above, to have an overview of how the two functionalities look like together.