### PR TITLE
PMR: Create or Delete AuthorizationPolicies

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,7 +6,7 @@ summary: A charm for automating the management of Kubeflow Profiles from a GitHu
 
 description: |
   A charm to automatically sync Kubeflow Profiles from information a GitHub repository.
-  
+
   This charm is responsible for monitoring a file from a GitHub repo that represents
   which Profiles and Contributors should exist in a cluster. Then, via a reconciliation loop
   the charm will update the Profiles and RoleBindings and AuthorizationPolicies in the
@@ -14,7 +14,7 @@ description: |
 
   It is useful for cluster administrators who want to automatically update
   the profiles on the cluster, based on a single source of truth.
-  
+
 base: ubuntu@24.04
 platforms:
   amd64:
@@ -48,6 +48,20 @@ config:
       description: |
         A configuration option to store the secret ID needed to access the SSH key for the GitHub
         repository
+    kfp-ui-principal:
+      default: "cluster.local/ns/kubeflow/sa/ml-pipeline-ui"
+      description: |
+        The Istio Principal for the KFP UI pod, needed for creating and updating the
+        AuthorizationPolicies in the cluster. The value depends on the ServiceAccount
+        of the KFP UI pod.
+      type: string
+    istio-ingressgateway-principal:
+      default: "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+      description: |
+        The Istio Principal for the Istio IngressGatewaty pod, needed for creating and updating the
+        AuthorizationPolicies in the cluster. The value depends on the ServiceAccount of the Istio
+        IngressGateway pod.
+      type: string
 
 containers:
   git-sync:

--- a/src/profiles_management/create_or_update.py
+++ b/src/profiles_management/create_or_update.py
@@ -27,10 +27,6 @@ from profiles_management.pmr.classes import ProfilesManagementRepresentation
 log = logging.getLogger(__name__)
 
 
-KFP_PRINCIPAL = "cluster.local/ns/kubeflow/sa/ml-pipeline-ui"
-ISTIO_PRINCIPAL = "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-
-
 def remove_access_to_stale_profile(client: Client, profile: GenericGlobalResource):
     """Remove access to all users from a Profile.
 
@@ -58,8 +54,8 @@ def remove_access_to_stale_profile(client: Client, profile: GenericGlobalResourc
 def create_or_update_profiles(
     client: Client,
     pmr: ProfilesManagementRepresentation,
-    kfp_ui_principal=KFP_PRINCIPAL,
-    istio_ingressgateway_principal=ISTIO_PRINCIPAL,
+    kfp_ui_principal: str,
+    istio_ingressgateway_principal: str,
 ):
     """Update the cluster to ensure Profiles and contributors are updated accordingly.
 

--- a/src/profiles_management/create_or_update.py
+++ b/src/profiles_management/create_or_update.py
@@ -27,6 +27,10 @@ from profiles_management.pmr.classes import ProfilesManagementRepresentation
 log = logging.getLogger(__name__)
 
 
+KFP_PRINCIPAL = "cluster.local/ns/kubeflow/sa/ml-pipeline-ui"
+ISTIO_PRINCIPAL = "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+
+
 def remove_access_to_stale_profile(client: Client, profile: GenericGlobalResource):
     """Remove access to all users from a Profile.
 
@@ -54,6 +58,8 @@ def remove_access_to_stale_profile(client: Client, profile: GenericGlobalResourc
 def create_or_update_profiles(
     client: Client,
     pmr: ProfilesManagementRepresentation,
+    kfp_ui_principal=KFP_PRINCIPAL,
+    istio_ingressgateway_principal=ISTIO_PRINCIPAL,
 ):
     """Update the cluster to ensure Profiles and contributors are updated accordingly.
 
@@ -72,6 +78,11 @@ def create_or_update_profiles(
         client: The lightkube client to use.
         pmr: The ProfilesManagementRepresentation expressing what Profiles and contributors
              should exist in the cluster.
+        kfp_ui_principal: The Istio principal of KFP UI, based on the ServiceAccount, to use
+                          when updating AuthorizationPolicies for Contributors.
+        istio_ingressgateway_principal: The Istio principal of IngressGateway, based on the
+                                        ServiceAccount, to use when updating AuthorizationPolicies
+                                        for Contributors.
 
     Raises:
         ApiError: From lightkube if an error occurred while trying to create or delete
@@ -102,11 +113,24 @@ def create_or_update_profiles(
             log.info("No Profile CR exists for Profile %s, creating it.", profile_name)
             existing_profile = profiles.apply_pmr_profile(client, profile)
 
+        # ResourceQuotas
         log.info("Creating or updating the ResourceQuota for Profile %s", profile_name)
         profiles.update_resource_quota(client, existing_profile, profile)
 
+        # RoleBindings
         log.info("Deleting RoleBindings that don't match Profile: %s", profile_name)
         kfam.delete_rolebindings_not_matching_profile_contributors(client, profile)
 
         log.info("Creating RoleBindings for Profile: %s", profile_name)
         kfam.create_rolebindings_for_profile_contributors(client, profile)
+
+        # AuthorizationPolicies
+        log.info("Deleting AuthorizationPolicies that don't match Profile: %s", profile_name)
+        kfam.delete_authorization_policies_not_matching_profile_contributors(
+            client, profile, kfp_ui_principal, istio_ingressgateway_principal
+        )
+
+        log.info("Creating AuthorizationPolicies for Profile: %s", profile_name)
+        kfam.create_authorization_policy_for_profile_contributors(
+            client, profile, kfp_ui_principal, istio_ingressgateway_principal
+        )

--- a/src/profiles_management/helpers/kfam.py
+++ b/src/profiles_management/helpers/kfam.py
@@ -429,7 +429,7 @@ def delete_authorization_policies_not_matching_profile_contributors(
     kfp_ui_principal: str,
     istio_ingressgateway_principal: str,
 ) -> None:
-    """Delete AuthorizationPolicies in the cluster that doesn't match Contributors in PMR Profile.
+    """Delete AuthorizationPolicies in the cluster that don't match Contributors in a PMR Profile.
 
     The function will be handling 404 errors, in case the AuthorizationPolicy doesn't exist in the
     cluster.

--- a/src/profiles_management/helpers/kfam.py
+++ b/src/profiles_management/helpers/kfam.py
@@ -238,7 +238,19 @@ def generate_contributor_authorization_policy(
     kfp_ui_principal: str,
     istio_ingressgateway_principal: str,
 ) -> GenericNamespacedResource:
-    """Generate AuthorizatioinPolicy for a PMR Contributor."""
+    """Generate AuthorizatioinPolicy for a PMR Contributor.
+
+    Args:
+        contributor: The PMR Contributor to generate a RoleBinding for.
+        namespace: The namespace to use for the RoleBinding.
+        kfp_ui_principal: The Istio principal of the KFP UI Pod, to put in the
+                          AuthorizationPolicy.
+        istio_ingressgateway_principal: The Istio principal of the Istio IngressGateway Pod
+                                        to put in the AuthorizationPolicy.
+
+    Returns:
+        The generated AuthorizationPolicy lightkube object for the contributor.
+    """
     name_rfc1123 = k8s.to_rfc1123_compliant(f"{contributor.name}-{contributor.role}")
 
     return AuthorizationPolicy.from_dict(

--- a/src/profiles_management/helpers/kfam.py
+++ b/src/profiles_management/helpers/kfam.py
@@ -13,6 +13,7 @@ from profiles_management.pmr.classes import Contributor, ContributorRole, Profil
 
 log = logging.getLogger(__name__)
 
+
 AuthorizationPolicy = create_namespaced_resource(
     group="security.istio.io",
     version="v1beta1",
@@ -105,10 +106,10 @@ def get_contributor_role(
     return ContributorRole(annotations["role"])
 
 
-def resource_matches_profile_contributor(
+def resource_matches_profile_contributor_name_role(
     resource: RoleBinding | GenericNamespacedResource, profile: Profile
 ) -> bool:
-    """Check if the user and its role in the RoleBinding match the PMR.
+    """Check if the user and its role match a Contributor in the Profile.
 
     Args:
         resource: The AuthorizationPolicy or RoleBinding to check if it matches any
@@ -124,6 +125,77 @@ def resource_matches_profile_contributor(
         return True
 
     return False
+
+
+def get_authorization_policy_principals(ap: GenericNamespacedResource) -> List[str] | None:
+    """Return principals from AuthorizationPolicy or None.
+
+    Args:
+        ap: The AuthorizationPolicy to return the principals from.
+
+    Returns:
+        The list of principals from the AuthorizationPolicy's first rule. If the rule
+        is not structured as expected, then None will be returned.
+    """
+    try:
+        return ap["spec"]["rules"][0]["from"][0]["source"]["principals"]
+    except (IndexError, KeyError):
+        return None
+
+
+def get_authorization_policy_header_user(ap: GenericNamespacedResource) -> str | None:
+    """Return value of kubeflow-userid header that should have namespace access.
+
+    Args:
+        ap: The AuthorizationPolicy to get the user it allows access to, if the header used is
+            "kubeflow-userid".
+
+    Returns:
+        The value of the user given access by the AuthorizationPolicy's first rule. If
+        rule is not structured as expected, then None will be returned.
+    """
+    try:
+        when = ap["spec"]["rules"][0]["when"][0]
+        if when["key"] == "request.headers[kubeflow-userid]":
+            return when["values"][0]
+    except (IndexError, KeyError):
+        return None
+
+
+def authorization_policy_grants_access_to_profile_contributor(
+    ap: GenericNamespacedResource,
+    profile: Profile,
+    kfp_ui_principal: str,
+    istio_ingressgateway_principal: str,
+) -> bool:
+    """Check if AuthorizationPolicy grants permission to a Profile Contributor.
+
+    For a user to have access in the Namespace the following 2 need to be valid:
+    1. The principals in the AuthorizationPolicy are as expected
+    2. The user in the AuthorizationPolicy matches an expected Profile Contributor
+
+    Args:
+        ap: The AuthorizationPolicy to check.
+        profile: The Profile to check if the AuthorizationPolicy refers to one of its
+                 Contributors.
+        kfp_ui_principal: The KFP UI Istio principal to use when checking the AuthorizationPolicy.
+        istio_ingressgateway_principal: The Istio IngressGateway Istio principal to use when
+                                        checking the AuthorizationPolicy.
+
+    Returns:
+        Boolean representing if the AuthorizationPolicy gives access to a Contributor of the
+        Profile to the Profile's namespace.
+    """
+    principals = get_authorization_policy_principals(ap)
+    user = get_authorization_policy_header_user(ap)
+
+    if not user or not principals:
+        return False
+
+    if kfp_ui_principal not in principals or istio_ingressgateway_principal not in principals:
+        return False
+
+    return user in profile._contributors_dict
 
 
 def generate_contributor_rolebinding(contributor: Contributor, namespace: str) -> RoleBinding:
@@ -156,6 +228,51 @@ def generate_contributor_rolebinding(contributor: Contributor, namespace: str) -
             "subjects": [
                 {"apiGroup": "rbac.authorization.k8s.io", "kind": "User", "name": contributor.name}
             ],
+        },
+    )
+
+
+def generate_contributor_authorization_policy(
+    contributor: Contributor,
+    namespace: str,
+    kfp_ui_principal: str,
+    istio_ingressgateway_principal: str,
+) -> GenericNamespacedResource:
+    """Generate AuthorizatioinPolicy for a PMR Contributor."""
+    name_rfc1123 = k8s.to_rfc1123_compliant(f"{contributor.name}-{contributor.role}")
+
+    return AuthorizationPolicy.from_dict(
+        {
+            "metadata": {
+                "name": name_rfc1123,
+                "namespace": namespace,
+                "annotations": {
+                    "user": contributor.name,
+                    "role": contributor.role,
+                },
+            },
+            "spec": {
+                "rules": [
+                    {
+                        "from": [
+                            {
+                                "source": {
+                                    "principals": [
+                                        kfp_ui_principal,
+                                        istio_ingressgateway_principal,
+                                    ]
+                                }
+                            }
+                        ],
+                        "when": [
+                            {
+                                "key": "request.headers[kubeflow-userid]",
+                                "values": [contributor.name],
+                            }
+                        ],
+                    }
+                ],
+            },
         },
     )
 
@@ -263,7 +380,7 @@ def delete_rolebindings_not_matching_profile_contributors(
         role_bindings_to_delete = existing_rolebindings
     else:
         for rb in existing_rolebindings:
-            if not resource_matches_profile_contributor(rb, profile):
+            if not resource_matches_profile_contributor_name_role(rb, profile):
                 log.info(
                     "RoleBinding '%s' doesn't belong to Profile. Will delete it.",
                     k8s.get_name(rb),
@@ -304,3 +421,90 @@ def create_rolebindings_for_profile_contributors(
         if contributor.role not in existing_contributor_roles.get(contributor.name, []):
             log.info("Will create RoleBinding for Contributor: %s", contributor)
             client.apply(generate_contributor_rolebinding(contributor, profile.name))
+
+
+def delete_authorization_policies_not_matching_profile_contributors(
+    client: Client,
+    profile: Profile,
+    kfp_ui_principal: str,
+    istio_ingressgateway_principal: str,
+) -> None:
+    """Delete AuthorizationPolicies in the cluster that doesn't match Contributors in PMR Profile.
+
+    The function will be handling 404 errors, in case the AuthorizationPolicy doesn't exist in the
+    cluster.
+
+    Args:
+        client: The lightkube client to use.
+        profile: The PMR Profile to create RoleBindings based on its Contributors.
+        kfp_ui_principal: The Istio principal of KFP UI, based on the ServiceAccount, to use
+                          when checking existing AuthorizationPolicies.
+        istio_ingressgateway_principal: The Istio principal of IngressGateway, based on the
+                                        ServiceAccount, to use when checking existing
+                                        AuthorizationPolicies.
+
+    Raises:
+        ApiError: From lightkube if something unexpected occurred while deleting the
+                  resources.
+    """
+    existing_authorization_policies = list_contributor_authorization_policies(client, profile.name)
+    authorization_policies_to_delete = []
+
+    if not profile.contributors:
+        authorization_policies_to_delete = existing_authorization_policies
+    else:
+        for ap in existing_authorization_policies:
+            if not resource_matches_profile_contributor_name_role(
+                ap, profile
+            ) or not authorization_policy_grants_access_to_profile_contributor(
+                ap, profile, kfp_ui_principal, istio_ingressgateway_principal
+            ):
+                log.info(
+                    "AuthorizationPolicy '%s' doesn't belong to Profile. Will delete it.",
+                    k8s.get_name(ap),
+                )
+                authorization_policies_to_delete.append(ap)
+
+    if authorization_policies_to_delete:
+        log.info("Deleting all resources that don't match the PMR.")
+        delete_many(client, authorization_policies_to_delete, logger=log)
+
+
+def create_authorization_policy_for_profile_contributors(
+    client: Client,
+    profile: Profile,
+    kfp_ui_principal: str,
+    istio_ingressgateway_principal: str,
+) -> None:
+    """Create AuthorizationPolicies for all contributors defined in a Profile, in the PMR.
+
+    If an AuthorizationPolicy already exists for the specific Contributor name and role, then
+    no API requests will happen.
+
+    Args:
+        client: The lightkube client to use.
+        profile: The PMR to iterate over its Contributors.
+        kfp_ui_principal: The Istio principal of KFP UI, based on the ServiceAccount, to use
+                          when creating AuthorizationPolicies for Contributors.
+        istio_ingressgateway_principal: The Istio principal of IngressGateway, based on the
+                                        ServiceAccount, to use when creating AuthorizationPolicies
+                                        for Contributors.
+
+    Raises:
+        ApiError: From lightkube if there was an error while trying to create the
+                  RoleBindings.
+    """
+    existing_policies = list_contributor_authorization_policies(client, profile.name)
+    existing_policies_dict = kfam_resources_list_to_roles_dict(existing_policies)
+
+    if not profile.contributors:
+        return
+
+    for contributor in profile.contributors:
+        if contributor.role not in existing_policies_dict.get(contributor.name, []):
+            log.info("Will create AuthorizationPolicy for Contributor: %s", contributor)
+            client.apply(
+                generate_contributor_authorization_policy(
+                    contributor, profile.name, kfp_ui_principal, istio_ingressgateway_principal
+                )
+            )

--- a/src/profiles_management/helpers/kfam.py
+++ b/src/profiles_management/helpers/kfam.py
@@ -374,8 +374,8 @@ def delete_rolebindings_not_matching_profile_contributors(
 ) -> None:
     """Delete RoleBindings in the cluster that doesn't match Contributors in PMR Profile.
 
-    The function will be handling 404 errors, in case the RoleBinding doesn't exist in the
-    cluster.
+    RoleBindings that no longer exist will not raise a 404 error, since underlying delete_many
+    handles this exception.
 
     Args:
         client: The lightkube client to use.
@@ -443,8 +443,8 @@ def delete_authorization_policies_not_matching_profile_contributors(
 ) -> None:
     """Delete AuthorizationPolicies in the cluster that don't match Contributors in a PMR Profile.
 
-    The function will be handling 404 errors, in case the AuthorizationPolicy doesn't exist in the
-    cluster.
+    AuthorizationPolicies that no longer exist will not raise a 404 error, since underlying
+    delete_many handles this exception.
 
     Args:
         client: The lightkube client to use.

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -120,8 +120,8 @@ async def test_update_resource_quota(lightkube_client: Client):
     profiles.remove_profile(profile, lightkube_client, wait_namespace=True)
 
 
-def test_surplus_rolebindings_are_deleted(lightkube_client: Client):
-    ns = "test-surplus-rolebindings-are-deleted"
+def test_surplus_profile_resources_are_deleted(lightkube_client: Client):
+    ns = "test-surplus-profile-resources-are-deleted"
     profile = profiles.apply_profile_and_resources(
         lightkube_client, profile_path=PROFILE_PATH, resources_path=RESOURCES_PATH, namespace=ns
     )
@@ -133,18 +133,21 @@ def test_surplus_rolebindings_are_deleted(lightkube_client: Client):
         resources={},
     )
 
-    log.info("Deleting superfluous RoleBindings from ")
+    log.info("Deleting superfluous Resources.")
     create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
 
     rbs = kfam.list_contributor_rolebindings(lightkube_client, ns)
     assert len(rbs) == 0
 
+    aps = kfam.list_contributor_authorization_policies(lightkube_client, ns)
+    assert len(aps) == 0
+
     profiles.remove_profile(profile, lightkube_client)
 
 
-def test_existing_rolebindings_are_updated(lightkube_client: Client):
-    """Existing RoleBinding for "permissions" should be updated to "admin"."""
-    ns = "test-existing-rolebindings-updated"
+def test_existing_profile_resources_are_updated(lightkube_client: Client):
+    """Existing RoleBinding and AuthorizationPolicies for should be updated to "admin"."""
+    ns = "test-existing-profile-resources-are-updated"
     profile = profiles.apply_profile_and_resources(
         lightkube_client, profile_path=PROFILE_PATH, resources_path=RESOURCES_PATH, namespace=ns
     )
@@ -158,7 +161,7 @@ def test_existing_rolebindings_are_updated(lightkube_client: Client):
         resources={},
     )
 
-    log.info("Updating existing RoleBindings from edit to be admin.")
+    log.info("Updating existing RBs / APs from edit to be admin.")
     create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
 
     rbs = kfam.list_contributor_rolebindings(lightkube_client, ns)
@@ -168,13 +171,21 @@ def test_existing_rolebindings_are_updated(lightkube_client: Client):
     assert rbs[0].metadata.annotations is not None
     assert rbs[0].metadata.annotations["user"] == user
     assert rbs[0].metadata.annotations["role"] == role
+    assert rbs[0].roleRef.name == "kubeflow-admin"
+
+    aps = kfam.list_contributor_authorization_policies(lightkube_client, ns)
+    assert len(aps) == 1
+    assert aps[0].metadata is not None
+    assert aps[0].metadata.annotations is not None
+    assert aps[0].metadata.annotations["user"] == user
+    assert aps[0].metadata.annotations["role"] == role
 
     profiles.remove_profile(profile, lightkube_client)
 
 
-def test_rolebindings_are_created(lightkube_client: Client):
-    """Existing RoleBinding for "permissions" should be updated to "admin"."""
-    ns = "test-rolebindings-created"
+def test_profile_resources_are_created(lightkube_client: Client):
+    """Existing RBs and APs for "permissions" should be updated to "admin"."""
+    ns = "test-profile-resources-are-created"
     profile = profiles.apply_profile_and_resources(
         lightkube_client, profile_path=PROFILE_PATH, namespace=ns
     )
@@ -188,15 +199,59 @@ def test_rolebindings_are_created(lightkube_client: Client):
         resources={},
     )
 
-    log.info("Creating RoleBinding for admin role.")
+    log.info("Creating resources for admin role.")
     create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
 
     rbs = kfam.list_contributor_rolebindings(lightkube_client, ns)
     assert len(rbs) == 1
-
     assert rbs[0].metadata is not None
     assert rbs[0].metadata.annotations is not None
     assert rbs[0].metadata.annotations["user"] == user
     assert rbs[0].metadata.annotations["role"] == role
+
+    aps = kfam.list_contributor_authorization_policies(lightkube_client, ns)
+    assert len(aps) == 1
+    assert aps[0].metadata is not None
+    assert aps[0].metadata.annotations is not None
+    assert aps[0].metadata.annotations["user"] == user
+    assert aps[0].metadata.annotations["role"] == role
+
+    profiles.remove_profile(profile, lightkube_client)
+
+
+def test_authorization_policies_with_incorrect_principals_are_updated(lightkube_client: Client):
+    ns = "test-authz-policies-with-incorrect-principals-are-updated"
+    profile = profiles.apply_profile_and_resources(
+        lightkube_client, profile_path=PROFILE_PATH, resources_path=RESOURCES_PATH, namespace=ns
+    )
+
+    # Same user/role as defined in YAML files.
+    # Only change will be the principal when calling create_or_update_profiles()
+    user = "kimonas@canonical.com"
+    role = ContributorRole.EDIT
+    pmr_profile = Profile(
+        name=ns,
+        owner=Owner(name=ns, kind=UserKind.USER),
+        contributors=[Contributor(name=user, role=role)],
+        resources={},
+    )
+
+    kfp_principal = "kfp-principal"
+    istio_principal = "istio-principal"
+
+    log.info("Running create_or_update_profiles but with different principals.")
+    create_or_update_profiles(
+        lightkube_client,
+        ProfilesManagementRepresentation([pmr_profile]),
+        kfp_principal,
+        istio_principal,
+    )
+
+    aps = kfam.list_contributor_authorization_policies(lightkube_client, ns)
+    assert len(aps) == 1
+
+    principals = aps[0]["spec"]["rules"][0]["from"][0]["source"]["principals"]
+    assert kfp_principal in principals
+    assert istio_principal in principals
 
     profiles.remove_profile(profile, lightkube_client)

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -54,7 +54,16 @@ async def test_remove_access_to_stale_profiles(
 
 
 @pytest.mark.asyncio
-async def test_new_profiles_created(lightkube_client: Client):
+async def test_new_profiles_are_created(lightkube_client: Client):
+    """Test that Profiles and expected resources are created, from Profile Controller.
+
+    This test will ensure that:
+    1. The resource quota, read from PMR, is valid and Profile Controller can create it.
+    2. The Profile Controller can create the default RoleBinding and AuthorizationPolicy, in
+       the Profile's namespace.
+
+    No contributor resources are tested here.
+    """
     pmr = classes.ProfilesManagementRepresentation()
 
     users = ["noha", "orfeas"]
@@ -157,8 +166,8 @@ def test_surplus_profile_resources_are_deleted(lightkube_client: Client):
     profiles.remove_profile(profile, lightkube_client)
 
 
-def test_existing_profile_resources_are_updated(lightkube_client: Client):
-    """Existing RoleBinding and AuthorizationPolicies should be updated to "admin"."""
+def test_existing_profile_contributor_resources_are_updated(lightkube_client: Client):
+    """Existing contributor RoleBinding and AuthorizationPolicies should be updated to "admin"."""
     ns = "test-existing-profile-resources-are-updated"
     profile = profiles.apply_profile_and_resources(
         lightkube_client, profile_path=PROFILE_PATH, resources_path=RESOURCES_PATH, namespace=ns
@@ -200,8 +209,8 @@ def test_existing_profile_resources_are_updated(lightkube_client: Client):
     profiles.remove_profile(profile, lightkube_client)
 
 
-def test_profile_resources_are_created(lightkube_client: Client):
-    """Existing RBs and APs for "permissions" should be updated to "admin"."""
+def test_profile_contributor_resources_are_created(lightkube_client: Client):
+    """Test contributor RBs and APs defined in PMR are created."""
     ns = "test-profile-resources-are-created"
     profile = profiles.apply_profile_and_resources(
         lightkube_client, profile_path=PROFILE_PATH, namespace=ns

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -258,8 +258,8 @@ def test_authorization_policies_with_incorrect_principals_are_updated(lightkube_
         resources={},
     )
 
-    kfp_principal = "kfp-principal"
-    istio_principal = "istio-principal"
+    kfp_principal = "different-kfp-principal"
+    istio_principal = "different-istio-principal"
 
     log.info("Running create_or_update_profiles but with different principals.")
     create_or_update_profiles(

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -22,6 +22,8 @@ log = logging.getLogger(__name__)
 TESTS_YAMLS_PATH = "tests/integration/profiles_management/yamls"
 PROFILE_PATH = TESTS_YAMLS_PATH + "/profile.yaml"
 RESOURCES_PATH = TESTS_YAMLS_PATH + "/contributor.yaml"
+KFP_PRINCIPAL = "cluster.local/ns/kubeflow/sa/ml-pipeline-ui"
+ISTIO_PRINCIPAL = "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
 
 
 @pytest.mark.asyncio
@@ -39,7 +41,7 @@ async def test_remove_access_to_stale_profiles(
     pmr = classes.ProfilesManagementRepresentation()
 
     log.info("Running create_or_update_profiles() which should remove access in above Profile.")
-    create_or_update_profiles(lightkube_client, pmr)
+    create_or_update_profiles(lightkube_client, pmr, KFP_PRINCIPAL, ISTIO_PRINCIPAL)
 
     rbs = kfam.list_contributor_rolebindings(lightkube_client, ns)
     assert len(rbs) == 0
@@ -66,7 +68,7 @@ async def test_new_profiles_created(lightkube_client: Client):
             )
         )
 
-    create_or_update_profiles(lightkube_client, pmr)
+    create_or_update_profiles(lightkube_client, pmr, KFP_PRINCIPAL, ISTIO_PRINCIPAL)
 
     log.info("Will check if Profiles were created as expected")
     for user in users:
@@ -104,7 +106,12 @@ async def test_update_resource_quota(lightkube_client: Client):
     )
 
     log.info("Updating Profile CR from expected PMR Profile: %s", pmr_profile)
-    create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
+    create_or_update_profiles(
+        lightkube_client,
+        ProfilesManagementRepresentation([pmr_profile]),
+        KFP_PRINCIPAL,
+        ISTIO_PRINCIPAL,
+    )
 
     updated_profile = profiles.get_profile(lightkube_client, ns)
     updated_quota = ResourceQuotaSpecModel.model_validate(
@@ -134,7 +141,12 @@ def test_surplus_profile_resources_are_deleted(lightkube_client: Client):
     )
 
     log.info("Deleting superfluous Resources.")
-    create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
+    create_or_update_profiles(
+        lightkube_client,
+        ProfilesManagementRepresentation([pmr_profile]),
+        KFP_PRINCIPAL,
+        ISTIO_PRINCIPAL,
+    )
 
     rbs = kfam.list_contributor_rolebindings(lightkube_client, ns)
     assert len(rbs) == 0
@@ -162,7 +174,12 @@ def test_existing_profile_resources_are_updated(lightkube_client: Client):
     )
 
     log.info("Updating existing RBs / APs from edit to be admin.")
-    create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
+    create_or_update_profiles(
+        lightkube_client,
+        ProfilesManagementRepresentation([pmr_profile]),
+        KFP_PRINCIPAL,
+        ISTIO_PRINCIPAL,
+    )
 
     rbs = kfam.list_contributor_rolebindings(lightkube_client, ns)
     assert len(rbs) == 1
@@ -200,7 +217,12 @@ def test_profile_resources_are_created(lightkube_client: Client):
     )
 
     log.info("Creating resources for admin role.")
-    create_or_update_profiles(lightkube_client, ProfilesManagementRepresentation([pmr_profile]))
+    create_or_update_profiles(
+        lightkube_client,
+        ProfilesManagementRepresentation([pmr_profile]),
+        KFP_PRINCIPAL,
+        ISTIO_PRINCIPAL,
+    )
 
     rbs = kfam.list_contributor_rolebindings(lightkube_client, ns)
     assert len(rbs) == 1

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -158,7 +158,7 @@ def test_surplus_profile_resources_are_deleted(lightkube_client: Client):
 
 
 def test_existing_profile_resources_are_updated(lightkube_client: Client):
-    """Existing RoleBinding and AuthorizationPolicies for should be updated to "admin"."""
+    """Existing RoleBinding and AuthorizationPolicies should be updated to "admin"."""
     ns = "test-existing-profile-resources-are-updated"
     profile = profiles.apply_profile_and_resources(
         lightkube_client, profile_path=PROFILE_PATH, resources_path=RESOURCES_PATH, namespace=ns

--- a/tests/unit/profiles-management/helpers/test_kfam.py
+++ b/tests/unit/profiles-management/helpers/test_kfam.py
@@ -5,11 +5,14 @@ from lightkube.models.rbac_v1 import RoleRef
 from lightkube.resources.rbac_authorization_v1 import RoleBinding
 
 from profiles_management.helpers.kfam import (
+    authorization_policy_grants_access_to_profile_contributor,
+    get_authorization_policy_header_user,
+    get_authorization_policy_principals,
     get_contributor_role,
     get_contributor_user,
     has_valid_kfam_annotations,
     resource_is_for_profile_owner,
-    resource_matches_profile_contributor,
+    resource_matches_profile_contributor_name_role,
 )
 from profiles_management.pmr.classes import Contributor, ContributorRole, Owner, Profile, UserKind
 
@@ -104,4 +107,156 @@ def test_contributor_getters():
     ],
 )
 def test_rolebinding_not_matching_empty_profile_contributors(rb, profile, matches_contributors):
-    assert resource_matches_profile_contributor(rb, profile) == matches_contributors
+    assert resource_matches_profile_contributor_name_role(rb, profile) == matches_contributors
+
+
+@pytest.mark.parametrize(
+    "ap,expected_principals",
+    [
+        (
+            GenericNamespacedResource(spec={"rules": []}),
+            None,
+        ),
+        (
+            GenericNamespacedResource(
+                spec={"rules": [{"from": [{"source": {"namespaces": ["test"]}}]}]}
+            ),
+            None,
+        ),
+        (
+            GenericNamespacedResource(
+                spec={"rules": [{"from": [{"source": {"principals": ["test"]}}]}]}
+            ),
+            ["test"],
+        ),
+    ],
+)
+def test_authorization_policy_principals(ap, expected_principals):
+    assert get_authorization_policy_principals(ap) == expected_principals
+
+
+@pytest.mark.parametrize(
+    "ap,expected_user",
+    [
+        # No rules
+        (
+            GenericNamespacedResource(spec={"rules": []}),
+            None,
+        ),
+        # empty when
+        (
+            GenericNamespacedResource(spec={"rules": [{"when": []}]}),
+            None,
+        ),
+        # AuthorizationPolicy not checking headers
+        (GenericNamespacedResource(spec={"rules": [{"when": [{"key": "source.ip"}]}]}), None),
+        # wrong header is used
+        (
+            GenericNamespacedResource(
+                spec={
+                    "rules": [
+                        {
+                            "when": [
+                                {
+                                    "key": "request.headers[kubeflow-wrong-header",
+                                    "values": ["admin"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ),
+            None,
+        ),
+        # Valid AuthorizationPolicy, user extracted as expected
+        (
+            GenericNamespacedResource(
+                spec={
+                    "rules": [
+                        {
+                            "when": [
+                                {
+                                    "key": "request.headers[kubeflow-userid]",
+                                    "values": ["user"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ),
+            "user",
+        ),
+    ],
+)
+def test_authorization_policy_user(ap, expected_user):
+    assert get_authorization_policy_header_user(ap) == expected_user
+
+
+@pytest.mark.parametrize(
+    "ap,profile,kfp_principal,istio_principal,grants_access",
+    [
+        # 1. incorrect AuthorizationPolicy
+        (GenericNamespacedResource(spec={"rules": [{"when": []}]}), None, "", "", False),
+        # 2. Valid AuthorizationPolicy, no matching contributor
+        (
+            GenericNamespacedResource(
+                spec={
+                    "rules": [
+                        {
+                            "from": [{"source": {"principals": ["kfp", "istio"]}}],
+                            "when": [
+                                {
+                                    "key": "request.headers[kubeflow-userid]",
+                                    "values": ["user"],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+            Profile(
+                name="test",
+                contributors=[Contributor(name="lalakis", role=ContributorRole.EDIT)],
+                owner=Owner(name="test", kind=UserKind.USER),
+            ),
+            "kfp",
+            "istio",
+            False,
+        ),
+        # 3. Valid AuthorizationPolicy, contributor matches
+        (
+            GenericNamespacedResource(
+                spec={
+                    "rules": [
+                        {
+                            "from": [{"source": {"principals": ["kfp", "istio"]}}],
+                            "when": [
+                                {
+                                    "key": "request.headers[kubeflow-userid]",
+                                    "values": ["user"],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+            Profile(
+                name="test",
+                contributors=[Contributor(name="user", role=ContributorRole.EDIT)],
+                owner=Owner(name="test", kind=UserKind.USER),
+            ),
+            "kfp",
+            "istio",
+            True,
+        ),
+    ],
+)
+def test_authz_policy_grants_profile_contributor_access(
+    ap, profile, kfp_principal, istio_principal, grants_access
+):
+    assert (
+        authorization_policy_grants_access_to_profile_contributor(
+            ap, profile, kfp_principal, istio_principal
+        )
+        == grants_access
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -58,7 +58,7 @@ def test_invalid_repository(harness: ops.testing.Harness[GithubProfilesAutomator
         "istio-ingressgateway-principal",
     ],
 )
-def test_empty_kfp_principal(
+def test_empty_principal_config(
     principal_key, harness: ops.testing.Harness[GithubProfilesAutomatorCharm]
 ):
     """Test that setting an empty value for the principal sets the status to Blocked."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -51,6 +51,26 @@ def test_invalid_repository(harness: ops.testing.Harness[GithubProfilesAutomator
     )
 
 
+@pytest.mark.parametrize(
+    "principal_key",
+    [
+        "kfp-ui-principal",
+        "istio-ingressgateway-principal",
+    ],
+)
+def test_empty_kfp_principal(
+    principal_key, harness: ops.testing.Harness[GithubProfilesAutomatorCharm]
+):
+    """Test that setting an empty value for the principal sets the status to Blocked."""
+    # Arrange
+    harness.update_config({principal_key: ""})
+    harness.begin()
+
+    # Assert
+    assert isinstance(harness.model.unit.status, BlockedStatus)
+    assert f"Config `{principal_key}` cannot be empty." in harness.charm.model.unit.status.message
+
+
 def test_not_leader(harness: ops.testing.Harness[GithubProfilesAutomatorCharm]):
     """Test that the current unit is not the leader."""
     # Arrange


### PR DESCRIPTION
Resolves https://github.com/canonical/github-profiles-automator/issues/31

This PR extends the `create_or_update_profiles(pmr)` function to:
1. create RoleBindings, for Contributors in the PMR if their RB doesn't exist
2. delete RoleBindings that don't match the Contributors in the PMR
## Changes
- Rename `resource_matches_profile_contributor` to `resource_matches_profile_contributor_name_role` to make it slightly more descriptive
- Helpers for fetching the principals of an AuthorizationPolicy, and the user it grants access to
- Helpers for checking when an AuthorizationPolicy grants access to a Contributor in a PMR Profile
- Extend `create_or_update_profiles` for creating/deleting AuthorizationPolicies
- Adds config options in the charm for `kfp-ui-principal` and `istio-ingressgateway-principal`
- Update the charm to pass the principals to `create_or_update_profiles()`
## Review Notes
- Was thinking of parametrising the integration tests for create/update resources, but in the end the code would be a bit more convoluted. If you think it could be done better and have suggestions let me know!
- I've added a short description on how to decide if an AuthorizationPolicy should be deleted in https://github.com/canonical/github-profiles-automator/issues/31#issuecomment-2615760426