### PR TITLE
PMR: use correct capitalisation on user kind

### DIFF
--- a/src/profiles_management/pmr/classes.py
+++ b/src/profiles_management/pmr/classes.py
@@ -91,8 +91,8 @@ class ResourceQuotaSpecModel(BaseModel):
 class UserKind(StrEnum):
     """Class representing the kind of the user as a Profile owner."""
 
-    USER = "user"
-    SERVICE_ACCOUNT = "service-account"
+    USER = "User"
+    SERVICE_ACCOUNT = "ServiceAccount"
 
 
 class ContributorRole(StrEnum):

--- a/tests/integration/profiles_management/test_create_or_update_profiles.py
+++ b/tests/integration/profiles_management/test_create_or_update_profiles.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 from lightkube import Client
+from lightkube.resources.rbac_authorization_v1 import RoleBinding
 
 from profiles_management.create_or_update import create_or_update_profiles
 from profiles_management.pmr import classes
@@ -73,7 +74,13 @@ async def test_new_profiles_created(lightkube_client: Client):
         created_profile_quota = classes.ResourceQuotaSpecModel.model_validate(
             created_profile["spec"]["resourceQuotaSpec"]
         )
+
         assert created_profile_quota == expected_quota
+        assert lightkube_client.get(RoleBinding, namespace=user, name="namespaceAdmin")
+        assert lightkube_client.get(
+            kfam.AuthorizationPolicy, namespace=user, name="ns-owner-access-istio"
+        )
+
         profiles.remove_profile(created_profile, lightkube_client)
 
 

--- a/tests/samples/pmr-sample-full.yaml
+++ b/tests/samples/pmr-sample-full.yaml
@@ -1,7 +1,7 @@
 profiles:
 - name: ml-engineers
   owner:
-    kind: user
+    kind: User
     name: admin@canonical.com
   resources:
     hard:
@@ -15,7 +15,7 @@ profiles:
     role: view
 - name: data-engineers
   owner:
-    kind: user
+    kind: User
     name: admin@canonical.com
   contributors:
   - name: daniela@canonical.com

--- a/tests/samples/pmr-sample-single.yaml
+++ b/tests/samples/pmr-sample-single.yaml
@@ -1,7 +1,7 @@
 profiles:
 - name: ml-engineers
   owner:
-    kind: user
+    kind: User
     name: admin@canonical.com
   resources:
     hard:


### PR DESCRIPTION
Resolves https://github.com/canonical/github-profiles-automator/issues/42

## Changes
- The user kind of the owner to be `User` or `ServiceAccount`, which is the expected capitalization
- Integration test that ensures the default Profile's RoleBinding and AuthorizationPolicy are created
- Update the sample PMR yamls to reflect the change
