### PR TITLE
Set the status on different exceptions that are raised

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -122,7 +122,7 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
             self.unit.status = e.status
         except Exception as e:
             logger.error(f"Could not sync profiles, due to the following error: {str(e)}")
-            self.unit.status = ops.BlockedStatus("")
+            self.unit.status = ops.BlockedStatus("Unexpected error, please look at the charm's logs for more details.")
 
     def _on_sync_now(self, event: ops.ActionEvent):
         """Log the Juju action and call sync_now()."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,14 +113,16 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
             self.on.delete_stale_profiles_action, self._on_delete_stale_profiles
         )
 
-    def _on_event_sync_profiles(self, event: ops.EventBase):
+    def _on_event_sync_profiles(self, _: ops.EventBase):
         """Update the Profiles if we can connect to the workload container."""
         try:
             self._sync_profiles()
-        except (ApiError, InvalidKfamAnnotationsError) as e:
-            logger.error(f"Could not sync profiles, due to the following error: {str(e)}")
         except ErrorWithStatus as e:
             logger.error(f"Could not sync profiles, due to the following error: {e.msg}")
+            self.unit.status = e.status
+        except Exception as e:
+            logger.error(f"Could not sync profiles, due to the following error: {str(e)}")
+            self.unit.status = ops.BlockedStatus("")
 
     def _on_sync_now(self, event: ops.ActionEvent):
         """Log the Juju action and call sync_now()."""
@@ -175,10 +177,12 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
         logger.info(f"Custom notice {event.notice.key} received, syncing profiles.")
         try:
             self._sync_profiles()
-        except (ApiError, InvalidKfamAnnotationsError) as e:
-            logger.error(f"Could not sync profiles, due to the following error: {str(e)}")
         except ErrorWithStatus as e:
             logger.error(f"Could not sync profiles, due to the following error: {e.msg}")
+            self.unit.status = e.status
+        except Exception as e:
+            logger.error(f"Could not sync profiles, due to the following error: {str(e)}")
+            self.unit.status = ops.BlockedStatus("")
 
     def _sync_profiles(self):
         """Sync the Kubeflow Profiles based on the YAML file at `pmr-yaml-path`."""
@@ -191,14 +195,16 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
                     str(self.config.get(ISTIO_PRINCIPAL_KEY)),
                 )
             except ApiError as e:
+                msg = "An unexpected ApiError happened. Please look at the logs for more details"
                 if e.status.code == 403:
                     logger.error(
                         "ApiError with status code 403 while updating profiles. "
                         "You may need to deploy to deploy this application with `--trust`."
                     )
-                else:
-                    logger.error(f"ApiError: {str(e)}")
-                raise
+                    msg = "Charm is missing required permissions. Make sure it has --trust."
+
+                logger.error(e)
+                raise ErrorWithStatus(msg, ops.BlockedStatus)
             except InvalidKfamAnnotationsError:
                 logger.error(
                     "InvalidKfamAnnotationsError: Profile doesn't have the expected annotations."

--- a/src/charm.py
+++ b/src/charm.py
@@ -199,7 +199,9 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
                     str(self.config.get(ISTIO_PRINCIPAL_KEY)),
                 )
             except ApiError as e:
-                msg = "An unexpected ApiError occurred. Please look at the charm's logs for more details."
+                msg = (
+                    "Unexpected error occurred. Please look at the charm's logs for more details."
+                )
                 if e.status.code == 403:
                     logger.error(
                         "ApiError with status code 403 while updating profiles. "

--- a/src/charm.py
+++ b/src/charm.py
@@ -199,7 +199,7 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
                     str(self.config.get(ISTIO_PRINCIPAL_KEY)),
                 )
             except ApiError as e:
-                msg = "An unexpected ApiError happened. Please look at the logs for more details"
+                msg = "An unexpected ApiError occurred. Please look at the charm's logs for more details."
                 if e.status.code == 403:
                     logger.error(
                         "ApiError with status code 403 while updating profiles. "

--- a/src/charm.py
+++ b/src/charm.py
@@ -199,7 +199,7 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
                 if e.status.code == 403:
                     logger.error(
                         "ApiError with status code 403 while updating profiles. "
-                        "You may need to deploy to deploy this application with `--trust`."
+                        "You may need to deploy this application with `--trust`."
                     )
                     msg = "Charm is missing required permissions. Make sure it has --trust."
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -122,7 +122,9 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
             self.unit.status = e.status
         except Exception as e:
             logger.error(f"Could not sync profiles, due to the following error: {str(e)}")
-            self.unit.status = ops.BlockedStatus("Unexpected error, please look at the charm's logs for more details.")
+            self.unit.status = ops.BlockedStatus(
+                "Unexpected error, please look at the charm's logs for more details."
+            )
 
     def _on_sync_now(self, event: ops.ActionEvent):
         """Log the Juju action and call sync_now()."""
@@ -182,7 +184,9 @@ class GithubProfilesAutomatorCharm(ops.CharmBase):
             self.unit.status = e.status
         except Exception as e:
             logger.error(f"Could not sync profiles, due to the following error: {str(e)}")
-            self.unit.status = ops.BlockedStatus("")
+            self.unit.status = ops.BlockedStatus(
+                "Unexpected error, please look at the charm's logs for more details."
+            )
 
     def _sync_profiles(self):
         """Sync the Kubeflow Profiles based on the YAML file at `pmr-yaml-path`."""


### PR DESCRIPTION
Closes https://github.com/canonical/github-profiles-automator/issues/25

Right now the Charm will go in a blocked status, but a lot of times it won't have a helpful error message. This PR improves the error handling to also set a status, but not when an action is triggered.

## Changes
1. Update the non-action handlers that call `_sync_profiles()` to set the status of the charm
2. Update `_sync_profiles()` to raise `ErrorWithStatus` on API errors

## Review Notes
Here's a following sequence of commands I tried and the corresponding charm statuses. In all cases shown the charm was in Blocked state.
```bash
juju deploy \
	./github-profiles-automator_amd64.charm \
	--resource \
	git-sync-image=registry.k8s.io/git-sync/git-sync:v4.4.0
# Config `repository` cannot be empty.

juju config \
	github-profiles-automator \
	repository=https://github.com/canonical/github-profiles-automator.git
#  Could not load YAML file at path pmr.yaml. You may need to configure `pmr-yaml-path`. Check the logs for more informa...

juju config \
	github-profiles-automator \
	pmr-yaml-path=tests/samples/pmr-sample-full.yaml
# Charm is missing required permissions. Make sure it has --trust.

juju config \
	github-profiles-automator \
	git-revision=incorrect-branch
# [git-sync-pebble-service] git-sync could not connect to the repository. You may need to configure the charm or add an...

juju config \
	github-profiles-automator \
	git-revision=main
# Charm is missing required permissions. Make sure it has --trust.

juju trust --scope=cluster github-profiles-automator
# Becase active
```