### PR TITLE
fix: Change URL validation to enable non-GitHub repositories

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -387,11 +387,6 @@ def is_ssh_url(url: str) -> bool:
     if url.startswith("git@"):
         if ":" not in url or "/" not in url:
             return False
-    elif url.startswith("ssh://git@"):
-        # Must include a path after the host
-        path_part = url[10:]
-        if "/" not in path_part:
-            return False
     else:
         return False
     return True

--- a/src/components/pebble_component.py
+++ b/src/components/pebble_component.py
@@ -69,12 +69,8 @@ class GitSyncPebbleService(PebbleServiceComponent):
             return
         inputs: GitSyncInputs = self._inputs_getter()
         if inputs.REPOSITORY_TYPE == RepositoryType.SSH:
-            if "://" in inputs.REPOSITORY:
-                # Handles ssh://git@provider/user/repo.git
-                host_part = inputs.REPOSITORY.split("://")[-1].split("/")[0]
-            else:
-                # Handles git@provider:user/repo.git
-                host_part = inputs.REPOSITORY.split(":")[0]
+            # Handles git@provider:user/repo.git
+            host_part = inputs.REPOSITORY.split(":")[0]
             return " ".join(
                 [
                     "ssh",


### PR DESCRIPTION
Closes #49

This PR updates the validation on the configuration options to enable non-GitHub repository URLs.

## To test
First, deploy all necessary charms:
```shell
juju add-model kubeflow
juju deploy kubeflow-profiles --channel=1.9/stable --trust

charmcraft pack
juju deploy ./github-profiles-automator_ubuntu@24.04-amd64.charm --trust --resource git-sync-image=registry.k8s.io/git-sync/git-sync:v4.4.0
```

Configure the charm to
```shell
juju config github-profiles-automator repository=git@gitlab.com:mvlassis/super-secret-repo.git
juju add-secret ssh-key-secret ssh-key="$(cat ~/.ssh/id_ed25519)"
juju grant-secret ssh-key-secret github-profiles-automator
juju config github-profiles-automator repository=<ssh-url>
juju config github-profiles-automator ssh-key-secret-id=secret:<secret-id>
juju config github-profiles-automator pmr-yaml-path=pmr-sample-simple.yaml
```

Get the profiles by running:
```
kubectl get profiles -A
```
Ensure health checks are working by running:
```shell
juju ssh github-profiles-automator/0 /bin/bash
/charm/bin/pebble checks
```