### PR TITLE
fix: New line in integration-charm test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ commands =
 	--tb native \
 	--log-cli-level=INFO \
 	{posargs} \
-	{[vars]tests_path}/integration
+	{[vars]tests_path}/integration \
 	--ignore={[vars]tests_path}/integration/profiles_management
 
 [testenv:integration-library]


### PR DESCRIPTION
## Summary

This PR includes a newline in the `integration-charm` tox environment, in order to include the `--ignore` argument we pass to ignore the library tests.