### PR TITLE
fix: grant `actions:read` to ci-tests caller job in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read
 
   release:
     strategy:


### PR DESCRIPTION
Added permissions: `{ actions: read, contents: read }` to the `ci-tests` job in `release.yaml` Same as done in #91 for other jobs.